### PR TITLE
Update to newrelic agent v5

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -33,20 +33,6 @@ exports.instrumentSegment = function instrumentSegment(segmentName, segmentFunc)
   }
 
   return function wrappedSegmentInvocation() {
-    var deferred = q.defer();
-
-    // createTracer returns the callback passed to it wrapped in code
-    // that concludes the measurement of the segment
-    var finishTrace = newrelic.createTracer(segmentName, function(err, result) {
-      if (err) return deferred.reject(err);
-      return deferred.resolve(result);
-    });
-
-    segmentFunc.apply(this, arguments).then(function(result) {
-      return finishTrace(null, result);
-    }).catch(function(err) {
-      return finishTrace(err);
-    });
-    return deferred.promise;
+    return newrelic.startSegment(segmentName, false, segmentFunc);
   };
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "3i-newrelic",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Third Iron Helpers pertaining to New Relic",
   "main": "lib/index.js",
   "scripts": {
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/thirdiron/node-3i-newrelic#readme",
   "dependencies": {
-    "newrelic": "^4.1.0",
+    "newrelic": ">=5.6.1",
     "q": "^1.5.1"
   }
 }


### PR DESCRIPTION
Replaces `createTracer` with `startSegment`, switches to >= versioning so that node-3i-newrelic picks up the version of the newrelic module used by the CMS (or other application)