### PR TITLE
Feature/bz 5175 fix newrelic helper function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -33,6 +33,6 @@ exports.instrumentSegment = function instrumentSegment(segmentName, segmentFunc)
   }
 
   return function wrappedSegmentInvocation() {
-    return newrelic.startSegment(segmentName, false, segmentFunc);
+    return newrelic.startSegment(segmentName, false, () => { return segmentFunc.apply(this, arguments); });
   };
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "3i-newrelic",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Third Iron Helpers pertaining to New Relic",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
The first revision of this function was failing to pass arguments along to the wrapped function.  This was causing instrumented functions to not received their parameters when called.  On the journals route, the `getLibrary` function is an instrumented function that was called.  Due to this error `getLibrary` didn't get its library id parameter, and instead of the library id would pass along `undefined` to the sql query as a parameter.  Thus the library lookup would fail and the journals route would return a 404 thinking that journals were requested for a non-existent library.